### PR TITLE
Don't calculate ip checksum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "convey"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "docopt 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "convey"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Ben Parli <bparli@gmail.com>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use self::config::Config;
 use docopt::Docopt;
 
 const USAGE: &'static str = "
-Convey 0.3.2
+Convey 0.3.3
 
 Usage:
   convey
@@ -36,7 +36,7 @@ Options:
 
 fn main() {
     env_logger::init();
-    let version = "0.3.2".to_owned();
+    let version = "0.3.3".to_owned();
     let args = Docopt::new(USAGE)
         .and_then(|dopt| dopt.version(Some(version)).parse())
         .unwrap_or_else(|e| e.exit());

--- a/src/passthrough/lb.rs
+++ b/src/passthrough/lb.rs
@@ -240,6 +240,7 @@ impl LB {
                 // since we'll be sending out with IP_HDRINCL set on raw socket the kernel
                 // will perform the checksum calculation on ip header anyway.  no need to do it twice
                 ip_header.set_checksum(0);
+                
                 mssg.bytes_tx = tcp_header.payload().len() as u64;
 
                 match tcp_header.get_flags() {


### PR DESCRIPTION
Since we're now sending out with IP_HDRINCL set on raw socket the kernel will perform the checksum calculation on the ip header anyway.  So there's no need to do it twice