### PR TITLE
Cleanup/CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run: >
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | 
           sh -s -- -v -y --profile minimal --default-toolchain <<parameters.toolchain>>
-      - run: sudo $HOME/.cargo/bin/cargo build
+      - run: sudo $HOME/.cargo/bin/cargo build --release
       - run: sudo $HOME/.cargo/bin/cargo test
       
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           command: rustup component add clippy
       - run:
           name: Run Clippy
-          command: sudo cargo clippy -- -W clippy::pedantic
+          command: cargo clippy -- -W clippy::pedantic
 
   build_and_test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,7 @@ jobs:
       toolchain:
         description: rust toolchain
         type: string
-    docker:
-      - image: buildpack-deps:trusty
+    machine: true
     steps:
       - checkout
       - run: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,21 +24,20 @@ jobs:
       - run:
           name: Run Clippy
           command: sudo cargo clippy -- -W clippy::pedantic
+
   build_and_test:
     parameters:
       toolchain:
         description: rust toolchain
         type: string
-
     docker:
       - image: buildpack-deps:trusty
-
     steps:
       - checkout
       - run: >
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | 
           sh -s -- -v -y --profile minimal --default-toolchain <<parameters.toolchain>>
-      - run: sudo $HOME/.cargo/bin/cargo build --release
+      - run: $HOME/.cargo/bin/cargo build --release
       - run: sudo $HOME/.cargo/bin/cargo test
       
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,54 @@
+version: 2.1
+
+jobs:
+  lint:
+    docker:
+      - image: rust
+    steps:
+      - checkout
+      - run:
+          name: Install cargo fmt
+          command: rustup component add rustfmt
+      - run:
+          name: Run lint
+          command: cargo fmt -- --check
+
+  clippy:
+    docker:
+      - image: rust
+    steps:
+      - checkout
+      - run:
+          name: Install cargo clippy
+          command: rustup component add clippy
+      - run:
+          name: Run Clippy
+          command: sudo cargo clippy -- -W clippy::pedantic
+  build_and_test:
+    parameters:
+      toolchain:
+        description: rust toolchain
+        type: string
+
+    docker:
+      - image: buildpack-deps:trusty
+
+    steps:
+      - checkout
+      - run: >
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | 
+          sh -s -- -v -y --profile minimal --default-toolchain <<parameters.toolchain>>
+      - run: sudo $HOME/.cargo/bin/cargo build
+      - run: sudo $HOME/.cargo/bin/cargo test
+      
+workflows:
+  version: 2.1
+
+  build:
+    jobs:
+      - lint
+      - clippy
+      - build_and_test:
+          matrix:
+            parameters:
+              toolchain: ["stable"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,6 @@ use std::sync::mpsc::channel;
 use std::sync::mpsc::Receiver;
 use std::thread;
 use std::time::Duration;
-use toml;
 
 #[derive(Debug, Clone)]
 pub struct Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ mod stats;
 use self::config::Config;
 use docopt::Docopt;
 
-const USAGE: &'static str = "
+const USAGE: &str = "
 Convey 0.3.3
 
 Usage:

--- a/src/passthrough/backend.rs
+++ b/src/passthrough/backend.rs
@@ -50,10 +50,10 @@ impl Backend {
     ) -> Backend {
         let pool = ServerPool::new_servers(servers);
         Backend {
-            name: name,
+            name,
             servers_map: Arc::new(RwLock::new(pool.servers_map)),
             ring: Arc::new(Mutex::new(pool.ring)),
-            health_check_interval: health_check_interval,
+            health_check_interval,
         }
     }
 
@@ -138,8 +138,6 @@ impl ServerPool {
                 } else {
                     backend_servers.insert(*server, false);
                 }
-            } else {
-                continue;
             }
         }
 

--- a/src/passthrough/lb.rs
+++ b/src/passthrough/lb.rs
@@ -240,7 +240,7 @@ impl LB {
                 // since we'll be sending out with IP_HDRINCL set on raw socket the kernel
                 // will perform the checksum calculation on ip header anyway.  no need to do it twice
                 ip_header.set_checksum(0);
-                
+
                 mssg.bytes_tx = tcp_header.payload().len() as u64;
 
                 match tcp_header.get_flags() {

--- a/src/passthrough/lb.rs
+++ b/src/passthrough/lb.rs
@@ -170,23 +170,23 @@ impl LB {
                         )),
                         port_mapper: Arc::new(RwLock::new(HashMap::new())),
                         next_port: Arc::new(Mutex::new(EPHEMERAL_PORT_LOWER)),
-                        workers: workers,
-                        dsr: dsr,
-                        stats_update_frequency: stats_update_frequency,
+                        workers,
+                        dsr,
+                        stats_update_frequency,
                     };
-                    return Some(new_lb);
+                    Some(new_lb)
                 }
                 _ => {
                     error!(
                         "Unable to configure load balancer server {:?}.  Only Ipv4 is supported",
                         front
                     );
-                    return None;
+                    None
                 }
             }
         } else {
             error!("Unable to configure load balancer server {:?}", front);
-            return None;
+            None
         }
     }
 
@@ -244,8 +244,8 @@ impl LB {
                 mssg.bytes_tx = tcp_header.payload().len() as u64;
 
                 match tcp_header.get_flags() {
-                    0b000010010 => mssg.connections = 1, // add a connection to count on SYN,ACK
-                    0b000010001 => mssg.connections = -1, // sub a connection to count on FIN,ACK
+                    0b0_0001_0010 => mssg.connections = 1, // add a connection to count on SYN,ACK
+                    0b0_0001_0001 => mssg.connections = -1, // sub a connection to count on FIN,ACK
                     _ => {}
                 }
 
@@ -259,12 +259,12 @@ impl LB {
 
                 return Some(Processed {
                     pkt_stats: mssg,
-                    ip_header: ip_header,
+                    ip_header,
                 });
             }
             _ => {} // ipv6 not supported (yet)
         }
-        return None;
+        None
     }
 
     // handle requests packets from a client
@@ -341,7 +341,7 @@ impl LB {
                         }
                         return Some(Processed {
                             pkt_stats: mssg,
-                            ip_header: ip_header,
+                            ip_header,
                         });
                     } else {
                         debug!(
@@ -414,7 +414,7 @@ impl LB {
                     let conn = Connection {
                         client: SocketAddr::new(IpAddr::V4(keep_client_ip), client_port),
                         backend_srv: node,
-                        ephem_port: ephem_port,
+                        ephem_port,
                     };
                     {
                         self.conn_tracker.write().unwrap().insert(cli, conn);
@@ -428,12 +428,12 @@ impl LB {
                             },
                         );
                     }
-                    return Some(Processed {
+                    Some(Processed {
                         pkt_stats: mssg,
-                        ip_header: ip_header,
-                    });
+                        ip_header,
+                    })
                 }
-                _ => return None,
+                _ => None
             }
         } else {
             error!("Unable to find backend");
@@ -442,7 +442,7 @@ impl LB {
             tcp_header.set_destination(tcp_header.get_source());
             if tcp_header.get_flags() == tcp::TcpFlags::SYN {
                 // reply ACK, RST
-                tcp_header.set_flags(0b000010100);
+                tcp_header.set_flags(0b0_0001_0100);
             } else {
                 tcp_header.set_flags(tcp::TcpFlags::RST);
             }
@@ -477,10 +477,10 @@ impl LB {
                 Err(e) => error!("{}", e),
             }
 
-            return Some(Processed {
+            Some(Processed {
                 pkt_stats: mssg,
-                ip_header: ip_header,
-            });
+                ip_header,
+            })
         }
     }
 
@@ -499,7 +499,7 @@ impl LB {
         if !self.dsr {
             new_source_ip = self.listen_ip;
         }
-        return (keep_client_ip, new_source_ip);
+        (keep_client_ip, new_source_ip)
     }
 }
 

--- a/src/passthrough/lb.rs
+++ b/src/passthrough/lb.rs
@@ -433,7 +433,7 @@ impl LB {
                         ip_header,
                     })
                 }
-                _ => None
+                _ => None,
             }
         } else {
             error!("Unable to find backend");

--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -48,7 +48,7 @@ impl Server {
             }
         }
         Server {
-            lbs: lbs,
+            lbs,
             config_rx: config.subscribe(),
         }
     }
@@ -277,7 +277,7 @@ fn setup_interface_cfg() -> linux::Config {
         rollover: false,
     });
     linux::Config {
-        fanout: fanout,
+        fanout,
         ..Default::default()
     }
 }

--- a/src/passthrough/utils.rs
+++ b/src/passthrough/utils.rs
@@ -30,7 +30,7 @@ pub fn find_local_addr() -> Option<Ipv4Addr> {
             }
         }
     }
-    return None;
+    None
 }
 
 // only use in tests!
@@ -73,7 +73,7 @@ pub fn build_dummy_ip(
     let checksum = pnet::packet::ipv4::checksum(&ip_header.to_immutable());
     ip_header.set_checksum(checksum);
 
-    return ip_header;
+    ip_header
 }
 
 // only use in tests!
@@ -94,7 +94,7 @@ pub fn build_dummy_eth(
     eth_header.set_ethertype(EtherTypes::Ipv4);
     eth_header.set_payload(&ip_header.packet());
 
-    return eth_header;
+    eth_header
 }
 
 // only use for health checks
@@ -123,5 +123,5 @@ pub fn find_interface(addr: Ipv4Addr) -> Option<NetworkInterface> {
             }
         }
     }
-    return None;
+    None
 }

--- a/src/proxy/backend.rs
+++ b/src/proxy/backend.rs
@@ -93,7 +93,7 @@ impl ServerPool {
 
         ServerPool {
             servers_map: backend_servers,
-            weights: weights,
+            weights,
             weighted_servers: weighted_backend_servers,
             dist: servers_dist,
         }
@@ -107,9 +107,9 @@ impl Backend {
         health_check_interval: u64,
     ) -> Backend {
         Backend {
-            name: name,
+            name,
             servers: Arc::new(RwLock::new(ServerPool::new_servers(servers))),
-            health_check_interval: health_check_interval,
+            health_check_interval,
         }
     }
 

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -71,7 +71,7 @@ impl Server {
                 );
                 let new_lb = Proxy {
                     name: name.clone(),
-                    listen_addr: listen_addr,
+                    listen_addr,
                     backend: Arc::new(backend),
                 };
                 new_server.proxies.push(Arc::new(new_lb));
@@ -227,8 +227,8 @@ async fn process(
                 frontend: Some(lb.name.clone()),
                 backend: lb.backend.name.clone(),
                 connections: -1,
-                bytes_tx: bytes_tx,
-                bytes_rx: bytes_rx,
+                bytes_tx,
+                bytes_rx,
                 servers: None,
             };
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -89,8 +89,8 @@ pub fn run(lb_config: &BaseConfig) -> Sender<StatsMssg> {
         current_connections: 0,
         total_bytes_rx: 0,
         total_bytes_tx: 0,
-        frontends: frontends,
-        backends: backends,
+        frontends,
+        backends,
     }));
 
     let handler = StatsApi {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -160,7 +160,10 @@ mod tests {
     fn test_stats() {
         let conf = Config::new("testdata/test.toml").unwrap();
         let tx = stats::run(&conf.base);
-        let mut data = reqwest::blocking::get("http://127.0.0.1:7000/stats").unwrap().json::<Stats>().unwrap();
+        let mut data = reqwest::blocking::get("http://127.0.0.1:7000/stats")
+            .unwrap()
+            .json::<Stats>()
+            .unwrap();
 
         assert_eq!(data.total_connections, 0);
         let test_bck = data.backends.get("tcp3000_out").unwrap();
@@ -176,7 +179,10 @@ mod tests {
         };
         tx.send(test_mssg).unwrap();
 
-        data = reqwest::blocking::get("http://127.0.0.1:7000/stats").unwrap().json::<Stats>().unwrap();
+        data = reqwest::blocking::get("http://127.0.0.1:7000/stats")
+            .unwrap()
+            .json::<Stats>()
+            .unwrap();
 
         assert_eq!(data.total_connections, 1);
         let test_bck = data.backends.get("tcp3000_out").unwrap();


### PR DESCRIPTION
- [x] Applied cargo fmt
- [x] Applied cargo clippy
- [x] Added CircleCI. You will need to  activate it on your profile.

A few remaining Clippy suggestions.
1. Don't name structs with the name of the module:
```
warning: item name ends with its containing module's name. You can always call `BaseConfig` as `config::Base`
  --> src/config.rs:19:1
   |
19 | / pub struct BaseConfig {
20 | |     pub frontends: HashMap<String, FrontendConfig>,
21 | |     pub backends: HashMap<String, BackendPool>,
22 | |     pub stats: Stats,
23 | |     pub passthrough: Option<Passthrough>,
24 | | }
   | |_^
   |
   = note: `-W clippy::module-name-repetitions` implied by `-W clippy::pedantic`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#module_name_repetitions
```
and
```
warning: item name starts with its containing module's name
  --> src/stats.rs:24:1
   |
24 | / pub struct StatsApi {
25 | |     stats: Arc<RwLock<Stats>>,
26 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#module_name_repetitions
```

2. If your enum is called `ReadError` all fields inside are errors, so it is kind of redundant to have `Error` in the enum fields.
```
warning: All variants have the same postfix: `Error`
  --> src/config.rs:57:1
   |
57 | / pub enum ReadError {
58 | |     IOError(IOError),
59 | |     ParseError(Vec<toml::de::Error>),
60 | |     DecodeError(toml::de::Error),
61 | | }
   | |_^
   |
   = note: `-W clippy::pub-enum-variant-names` implied by `-W clippy::pedantic`
   = help: remove the postfixes and use full paths to the variants instead of glob imports
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#pub_enum_variant_names
```

3. it seems that `tokio::prelude` is unused here:
```
warning: unused import: `tokio::prelude`
  --> src/proxy/mod.rs:11:5
   |
11 | use tokio::prelude::*;
   |     ^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```